### PR TITLE
Implement the fixed size hash map for fast evaluation of expression.

### DIFF
--- a/cppmh/model/constraint.h
+++ b/cppmh/model/constraint.h
@@ -249,6 +249,8 @@ class Constraint {
         m_sense      = a_SENSE;
         m_is_linear  = true;
 
+        m_expression.setup_fixed_sensitivities();
+
         m_constraint_function =
             [this](const Move<T_Variable, T_Expression> &a_MOVE) {
                 return m_expression.evaluate(a_MOVE);

--- a/cppmh/model/expression.h
+++ b/cppmh/model/expression.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include <unordered_map>
 
+#include "fixed_size_hash_map.h"
 #include "move.h"
 
 namespace cppmh {
@@ -62,6 +63,9 @@ class Expression {
 
     std::unordered_map<Variable<T_Variable, T_Expression> *, T_Expression>
         m_sensitivities;
+
+    FixedSizeHashMap<Variable<T_Variable, T_Expression> *, T_Expression>
+        m_fixed_sensitivities;
 
     /*************************************************************************/
     /// Default constructor
@@ -134,8 +138,7 @@ class Expression {
         m_value                   = 0;
         m_is_enabled              = true;
         m_sensitivities.clear();
-        m_sensitivities.reserve(
-            ExpressionConstant::DEFAULT_SENSITIVITY_RESERVE_SIZE);
+        m_fixed_sensitivities.initialize();
     }
 
     /*************************************************************************/
@@ -175,6 +178,18 @@ class Expression {
     }
 
     /*************************************************************************/
+    inline constexpr void setup_fixed_sensitivities(void) {
+        /**
+         * std::unordered_map is slow in hashing because it uses modulo
+         * operations. For efficient evaluations of solutions, A hash map
+         * without modulo operations is set up by converting from the
+         * std::unordered map.
+         */
+        m_fixed_sensitivities.setup(m_sensitivities,
+                                    sizeof(Variable<T_Variable, T_Expression>));
+    }
+
+    /*************************************************************************/
     inline constexpr T_Expression constant_value(void) const {
         return m_constant_value;
     }
@@ -191,22 +206,15 @@ class Expression {
 
     /*************************************************************************/
     inline constexpr T_Expression evaluate(
-        const Move<T_Variable, T_Expression> &a_MOVE) noexcept {
-        /**
-         * This method is not const to use std::unordered_map.operator[] which
-         * is non-const method.
-         */
+        const Move<T_Variable, T_Expression> &a_MOVE) const noexcept {
         if (a_MOVE.alterations.size() == 0) {
             return this->evaluate();
         }
 
         T_Expression new_value = m_value;
         for (const auto &alteration : a_MOVE.alterations) {
-            if (m_sensitivities.find(alteration.first) !=
-                m_sensitivities.end()) {
-                new_value += m_sensitivities[alteration.first] *
-                             (alteration.second - alteration.first->value());
-            }
+            new_value += m_fixed_sensitivities.at(alteration.first) *
+                         (alteration.second - alteration.first->value());
         }
         return new_value;
     }
@@ -378,7 +386,7 @@ class Expression {
         m_constant_value /= a_VALUE;
         return *this;
     }
-};
+};  // namespace model
 using IPExpression = Expression<int, double>;
 }  // namespace model
 }  // namespace cppmh

--- a/cppmh/model/fixed_size_hash_map.h
+++ b/cppmh/model/fixed_size_hash_map.h
@@ -1,0 +1,157 @@
+/*****************************************************************************/
+// Copyright (c) 2020 Yuji KOGUMA
+// Released under the MIT license
+// https://opensource.org/licenses/mit-license.php
+/*****************************************************************************/
+#ifndef CPPMH_MODEL_FIXED_SIZE_HASH_MAP__
+#define CPPMH_MODEL_FIXED_SIZE_HASH_MAP__
+
+#include <vector>
+#include <unordered_map>
+#include <cmath>
+#include <iostream>
+
+namespace cppmh {
+namespace model {
+/*****************************************************************************/
+struct FixedSizeHashMapConstant {
+    static constexpr std::size_t DEFAULT_BUCKET_SIZE = 16;
+    static constexpr int         LOAD_MARGIN         = 2;
+};
+
+/*****************************************************************************/
+template <class T_Key, class T_Value>
+class FixedSizeHashMap {
+   private:
+    unsigned int m_shift_size;
+    std::size_t  m_bucket_size;
+
+    std::vector<T_Key>   m_keys;
+    std::vector<T_Value> m_values;
+    std::vector<bool>    m_is_occupied;
+
+    /*************************************************************************/
+    inline constexpr std::size_t compute_hash(const T_Key a_KEY) const
+        noexcept {
+        return reinterpret_cast<std::size_t>(a_KEY) >> m_shift_size;
+    }
+
+    /*************************************************************************/
+    inline constexpr std::size_t compute_index(const std::size_t a_HASH) const
+        noexcept {
+        return a_HASH & (m_bucket_size - 1);
+    }
+
+    /*************************************************************************/
+    inline void insert(const T_Key a_KEY, const T_Value a_VALUE) {
+        /**
+         * This method is provided as private and is called only by setup().
+         */
+        std::size_t index = this->compute_index(this->compute_hash(a_KEY));
+        while (m_is_occupied[index]) {
+            index = compute_index(index + 1);
+        }
+
+        m_is_occupied[index] = true;
+        m_keys[index]        = a_KEY;
+        m_values[index]      = a_VALUE;
+    }
+
+   public:
+    /*************************************************************************/
+    FixedSizeHashMap(void) {
+        this->initialize();
+    }
+
+    /*************************************************************************/
+    FixedSizeHashMap(const std::unordered_map<T_Key, T_Value> &a_UNORDERED_MAP,
+                     const std::size_t                         a_KEY_SIZE) {
+        this->setup(a_UNORDERED_MAP, a_KEY_SIZE);
+    }
+
+    /*************************************************************************/
+    inline constexpr void initialize(void) {
+        m_shift_size  = 0;
+        m_bucket_size = FixedSizeHashMapConstant::DEFAULT_BUCKET_SIZE;
+        m_keys.resize(m_bucket_size, 0);
+        m_values.resize(m_bucket_size, 0);
+        m_is_occupied.resize(m_bucket_size, 0);
+
+        std::fill(m_keys.begin(), m_keys.end(), static_cast<T_Key>(0));
+        std::fill(m_values.begin(), m_values.end(), static_cast<T_Value>(0));
+        std::fill(m_is_occupied.begin(), m_is_occupied.end(), false);
+    }
+
+    /*************************************************************************/
+    inline void setup(const std::unordered_map<T_Key, T_Value> &a_UNORDERED_MAP,
+                      const std::size_t                         a_KEY_SIZE) {
+        m_shift_size = floor(log2(a_KEY_SIZE));
+
+        std::size_t minimum_bucket_size =
+            a_UNORDERED_MAP.size() * FixedSizeHashMapConstant::LOAD_MARGIN;
+        std::size_t bucket_size = 1;
+        while (bucket_size < minimum_bucket_size) {
+            bucket_size <<= 1;
+        }
+        m_bucket_size = bucket_size;
+
+        m_keys.resize(m_bucket_size);
+        m_values.resize(m_bucket_size);
+        m_is_occupied.resize(m_bucket_size);
+
+        std::fill(m_keys.begin(), m_keys.end(), static_cast<T_Key>(0));
+        std::fill(m_values.begin(), m_values.end(), static_cast<T_Value>(0));
+        std::fill(m_is_occupied.begin(), m_is_occupied.end(), false);
+
+        for (const auto &item : a_UNORDERED_MAP) {
+            this->insert(item.first, item.second);
+        }
+    }
+
+    /*************************************************************************/
+    inline constexpr const T_Value at(const T_Key a_KEY) const noexcept {
+        std::size_t index = this->compute_index(this->compute_hash(a_KEY));
+        if (!m_is_occupied[index]) {
+            return 0;
+        }
+
+        while (m_keys[index] != a_KEY) {
+            if (!m_is_occupied[index]) {
+                return 0;
+            }
+            index = compute_index(index + 1);
+        }
+        return m_values[index];
+    }
+
+    /*************************************************************************/
+    inline constexpr unsigned int shift_size(void) const {
+        return m_shift_size;
+    }
+
+    /*************************************************************************/
+    inline constexpr std::size_t bucket_size(void) const {
+        return m_bucket_size;
+    }
+
+    /*************************************************************************/
+    inline constexpr const std::vector<T_Key> &keys(void) const {
+        return m_keys;
+    }
+
+    /*************************************************************************/
+    inline constexpr const std::vector<T_Value> &values(void) const {
+        return m_values;
+    }
+
+    /*************************************************************************/
+    inline constexpr const std::vector<bool> &is_occupied(void) const {
+        return m_is_occupied;
+    }
+};
+}  // namespace model
+}  // namespace cppmh
+#endif
+/*****************************************************************************/
+// END
+/*****************************************************************************/

--- a/cppmh/model/model.h
+++ b/cppmh/model/model.h
@@ -512,6 +512,15 @@ class Model {
     }
 
     /*************************************************************************/
+    inline constexpr void setup_fixed_sensitivities(void) {
+        for (auto &&proxy : m_expression_proxies) {
+            for (auto &&expression : proxy.flat_indexed_expressions()) {
+                expression.setup_fixed_sensitivities();
+            }
+        }
+    }
+
+    /*************************************************************************/
     inline constexpr void reset_variable_sense(void) {
         for (auto &&proxy : m_variable_proxies) {
             for (auto &&variable : proxy.flat_indexed_variables()) {
@@ -1124,7 +1133,7 @@ class Model {
         void) const {
         return m_constraint_names;
     }
-};  // namespace model
+};
 using IPModel = Model<int, double>;
 }  // namespace model
 }  // namespace cppmh

--- a/cppmh/model/objective.h
+++ b/cppmh/model/objective.h
@@ -154,6 +154,7 @@ class Objective {
         this->initialize();
         m_is_linear  = true;
         m_expression = a_EXPRESSION;
+        m_expression.setup_fixed_sensitivities();
     }
 
     /*************************************************************************/
@@ -193,6 +194,11 @@ class Objective {
         } else {
             m_value = m_function(a_MOVE);
         }
+    }
+
+    /*************************************************************************/
+    inline constexpr Expression<T_Variable, T_Expression> &expression(void) {
+        return m_expression;
     }
 
     /*************************************************************************/

--- a/cppmh/solver/solver.h
+++ b/cppmh/solver/solver.h
@@ -80,6 +80,8 @@ model::NamedSolution<T_Variable, T_Expression> solve(
     model->setup_default_neighborhood(
         master_option.is_enabled_parallel_neighborhood_update);
 
+    model->setup_fixed_sensitivities();
+
     /**
      * If the user-defined_neighborhood is set, default neighborhood should
      * be disabled to avoid possible inconsistencies.

--- a/test/model/test_constraint.cpp
+++ b/test/model/test_constraint.cpp
@@ -202,6 +202,7 @@ TEST_F(TestConstraint, setup_arg_function) {
     auto target      = random_integer();
 
     expression = sensitivity * variable + constant;
+
     std::function<double(const cppmh::model::Move<int, double> &)> f =
         [&expression, target](const cppmh::model::Move<int, double> &a_MOVE) {
             return expression.evaluate(a_MOVE) - target;
@@ -329,6 +330,7 @@ TEST_F(TestConstraint, evaluate_function_arg_void) {
     auto target      = random_integer();
 
     expression = sensitivity * variable + constant;
+
     std::function<double(const cppmh::model::Move<int, double> &)> f =
         [&expression, target](const cppmh::model::Move<int, double> &a_MOVE) {
             return expression.evaluate(a_MOVE) - target;
@@ -380,6 +382,8 @@ TEST_F(TestConstraint, evaluate_function_arg_move) {
     auto target      = random_integer();
 
     expression = sensitivity * variable + constant;
+    expression.setup_fixed_sensitivities();
+
     std::function<double(const cppmh::model::Move<int, double> &)> f =
         [&expression, target](const cppmh::model::Move<int, double> &a_MOVE) {
             return expression.evaluate(a_MOVE) - target;
@@ -465,6 +469,7 @@ TEST_F(TestConstraint, evaluate_violation_function_arg_void) {
     auto target      = random_integer();
 
     expression = sensitivity * variable + constant;
+
     std::function<double(const cppmh::model::Move<int, double> &)> f =
         [&expression, target](const cppmh::model::Move<int, double> &a_MOVE) {
             return expression.evaluate(a_MOVE) - target;
@@ -590,6 +595,8 @@ TEST_F(TestConstraint, evaluate_violation_function_arg_move) {
     auto target      = random_integer();
 
     expression = sensitivity * variable + constant;
+    expression.setup_fixed_sensitivities();
+
     std::function<double(const cppmh::model::Move<int, double> &)> f =
         [&expression, target](const cppmh::model::Move<int, double> &a_MOVE) {
             return expression.evaluate(a_MOVE) - target;
@@ -888,6 +895,7 @@ TEST_F(TestConstraint, operator_equal_function) {
     auto target      = random_integer();
 
     expression = sensitivity * variable + constant;
+
     std::function<double(const cppmh::model::Move<int, double> &)> f =
         [&expression, target](const cppmh::model::Move<int, double> &a_MOVE) {
             return expression.evaluate(a_MOVE) - target;

--- a/test/model/test_constraint_proxy.cpp
+++ b/test/model/test_constraint_proxy.cpp
@@ -42,7 +42,7 @@ TEST_F(TestConstraintProxy, scalar_create_instance) {
 }
 
 /*****************************************************************************/
-TEST_F(TestConstraintProxy, scalar_constraints_arg_void) {
+TEST_F(TestConstraintProxy, scalar_flat_indexed_constraints_arg_void) {
     cppmh::model::Model<int, double> model;
     auto& constraint_proxy = model.create_constraint("c");
 
@@ -66,7 +66,7 @@ TEST_F(TestConstraintProxy, scalar_constraints_arg_void) {
 }
 
 /*****************************************************************************/
-TEST_F(TestConstraintProxy, scalar_constraints_arg_int) {
+TEST_F(TestConstraintProxy, scalar_flat_indexed_constraints_arg_int) {
     cppmh::model::Model<int, double> model;
     auto& constraint_proxy = model.create_constraint("c");
 
@@ -263,7 +263,7 @@ TEST_F(TestConstraintProxy, one_dimensional_create_instance) {
 }
 
 /*****************************************************************************/
-TEST_F(TestConstraintProxy, one_dimensional_constraints_arg_void) {
+TEST_F(TestConstraintProxy, one_dimensional_flat_indexed_constraints_arg_void) {
     cppmh::model::Model<int, double> model;
     auto& constraint_proxy = model.create_constraints("c", 2);
 
@@ -296,7 +296,7 @@ TEST_F(TestConstraintProxy, one_dimensional_constraints_arg_void) {
 }
 
 /*****************************************************************************/
-TEST_F(TestConstraintProxy, one_dimensional_constraints_arg_int) {
+TEST_F(TestConstraintProxy, one_dimensional_flat_indexed_constraints_arg_int) {
     cppmh::model::Model<int, double> model;
     auto& constraint_proxy = model.create_constraints("c", 2);
 
@@ -514,7 +514,7 @@ TEST_F(TestConstraintProxy, two_dimensional_create_instance) {
 }
 
 /*****************************************************************************/
-TEST_F(TestConstraintProxy, two_dimensional_constraints_arg_void) {
+TEST_F(TestConstraintProxy, two_dimensional_flat_indexed_constraints_arg_void) {
     cppmh::model::Model<int, double> model;
     auto& constraint_proxy = model.create_constraints("c", {2, 3});
 
@@ -549,7 +549,7 @@ TEST_F(TestConstraintProxy, two_dimensional_constraints_arg_void) {
 }
 
 /*****************************************************************************/
-TEST_F(TestConstraintProxy, two_dimensional_constraints_arg_int) {
+TEST_F(TestConstraintProxy, two_dimensional_flat_indexed_constraints_arg_int) {
     cppmh::model::Model<int, double> model;
     auto& constraint_proxy = model.create_constraints("c", {2, 3});
 
@@ -862,16 +862,16 @@ TEST_F(TestConstraintProxy,
 
     auto  variable = cppmh::model::Variable<int, double>::create_instance();
     auto& constraint_proxy = model.create_constraints("c", {2, 3, 4, 5});
-    auto  sentisivity_0    = random_integer();
-    auto  sentisivity_1    = random_integer();
+    auto  sensitivity_0    = random_integer();
+    auto  sensitivity_1    = random_integer();
 
-    constraint_proxy({0, 0, 0, 0}) = (sentisivity_0 * variable == 0);
-    constraint_proxy({1, 2, 3, 4}) = (sentisivity_1 * variable == 0);
-    EXPECT_EQ(sentisivity_0, constraint_proxy({0, 0, 0, 0})
+    constraint_proxy({0, 0, 0, 0}) = (sensitivity_0 * variable == 0);
+    constraint_proxy({1, 2, 3, 4}) = (sensitivity_1 * variable == 0);
+    EXPECT_EQ(sensitivity_0, constraint_proxy({0, 0, 0, 0})
                                  .expression()
                                  .sensitivities()
                                  .at(&variable));
-    EXPECT_EQ(sentisivity_1, constraint_proxy({1, 2, 3, 4})
+    EXPECT_EQ(sensitivity_1, constraint_proxy({1, 2, 3, 4})
                                  .expression()
                                  .sensitivities()
                                  .at(&variable));

--- a/test/model/test_expression.cpp
+++ b/test/model/test_expression.cpp
@@ -43,11 +43,11 @@ TEST_F(TestExpression, initialize) {
 
 /*****************************************************************************/
 TEST_F(TestExpression, set_flat_index) {
-    auto variable = cppmh::model::Variable<int, double>::create_instance();
+    auto expression = cppmh::model::Expression<int, double>::create_instance();
 
     auto flat_index = random_integer();
-    variable.set_flat_index(flat_index);
-    EXPECT_EQ(flat_index, variable.flat_index());
+    expression.set_flat_index(flat_index);
+    EXPECT_EQ(flat_index, expression.flat_index());
 }
 
 /*****************************************************************************/
@@ -57,16 +57,18 @@ TEST_F(TestExpression, flat_index) {
 
 /*****************************************************************************/
 TEST_F(TestExpression, set_multi_dimensional_index) {
-    auto variable = cppmh::model::Variable<int, double>::create_instance();
+    auto expression = cppmh::model::Expression<int, double>::create_instance();
 
     auto multi_dimensional_index_1 = random_integer();
     auto multi_dimensional_index_2 = random_integer();
 
-    variable.set_multi_dimensional_index(
+    expression.set_multi_dimensional_index(
         {multi_dimensional_index_1, multi_dimensional_index_2});
 
-    EXPECT_EQ(multi_dimensional_index_1, variable.multi_dimensional_index()[0]);
-    EXPECT_EQ(multi_dimensional_index_2, variable.multi_dimensional_index()[1]);
+    EXPECT_EQ(multi_dimensional_index_1,
+              expression.multi_dimensional_index()[0]);
+    EXPECT_EQ(multi_dimensional_index_2,
+              expression.multi_dimensional_index()[1]);
 }
 
 /*****************************************************************************/
@@ -99,6 +101,11 @@ TEST_F(TestExpression, set_sensitivities) {
 /*****************************************************************************/
 TEST_F(TestExpression, sensitivities) {
     /// This method is tested in set_sensitivities().
+}
+
+/*****************************************************************************/
+TEST_F(TestExpression, setup_fixed_sensitivities) {
+    /// This method is tested in test_fixed_size_hash_map().
 }
 
 /*****************************************************************************/
@@ -153,6 +160,7 @@ TEST_F(TestExpression, evaluate_arg_move) {
 
     expression =
         sensitivity_0 * variable_0 + sensitivity_1 * variable_1 + constant;
+    expression.setup_fixed_sensitivities();
 
     auto v_value_0 = random_integer();
     auto v_value_1 = random_integer();
@@ -219,6 +227,7 @@ TEST_F(TestExpression, update_arg_move) {
 
     expression =
         sensitivity_0 * variable_0 + sensitivity_1 * variable_1 + constant;
+    expression.setup_fixed_sensitivities();
 
     auto v_value_0 = random_integer();
     auto v_value_1 = random_integer();

--- a/test/model/test_expression_proxy.cpp
+++ b/test/model/test_expression_proxy.cpp
@@ -106,6 +106,10 @@ TEST_F(TestExpressionProxy, scalar_evaluate_arg_move) {
     expression_proxy =
         sensitivity_0 * variable_0 + sensitivity_1 * variable_1 + constant;
 
+    for (auto&& expression : expression_proxy.flat_indexed_expressions()) {
+        expression.setup_fixed_sensitivities();
+    }
+
     auto value_0 = random_integer();
     auto value_1 = random_integer();
 
@@ -170,6 +174,10 @@ TEST_F(TestExpressionProxy, scalar_update_arg_move) {
     expression_proxy =
         sensitivity_0 * variable_0 + sensitivity_1 * variable_1 + constant;
 
+    for (auto&& expression : expression_proxy.flat_indexed_expressions()) {
+        expression.setup_fixed_sensitivities();
+    }
+
     auto value_0 = random_integer();
     auto value_1 = random_integer();
 
@@ -198,7 +206,7 @@ TEST_F(TestExpressionProxy, scalar_value) {
 }
 
 /*****************************************************************************/
-TEST_F(TestExpressionProxy, scalar_expressions_arg_void) {
+TEST_F(TestExpressionProxy, scalar_flat_indexed_expressions_arg_void) {
     cppmh::model::Model<int, double> model;
     auto& expression_proxy = model.create_expression("e");
 
@@ -229,7 +237,7 @@ TEST_F(TestExpressionProxy, scalar_expressions_arg_void) {
 }
 
 /*****************************************************************************/
-TEST_F(TestExpressionProxy, scalar_expressions_arg_int) {
+TEST_F(TestExpressionProxy, scalar_flat_indexed_expressions_arg_int) {
     cppmh::model::Model<int, double> model;
     auto& expression_proxy = model.create_expression("e");
 
@@ -789,7 +797,7 @@ TEST_F(TestExpressionProxy, one_dimensional_value) {
 }
 
 /*****************************************************************************/
-TEST_F(TestExpressionProxy, one_dimensional_expressions_arg_void) {
+TEST_F(TestExpressionProxy, one_dimensional_flat_indexed_expressions_arg_void) {
     cppmh::model::Model<int, double> model;
     auto& expression_proxy = model.create_expressions("e", 2);
 
@@ -832,7 +840,7 @@ TEST_F(TestExpressionProxy, one_dimensional_expressions_arg_void) {
 }
 
 /*****************************************************************************/
-TEST_F(TestExpressionProxy, one_dimensional_expressions_arg_int) {
+TEST_F(TestExpressionProxy, one_dimensional_flat_indexed_expressions_arg_int) {
     cppmh::model::Model<int, double> model;
     auto& expression_proxy = model.create_expressions("e", 2);
 
@@ -1305,7 +1313,7 @@ TEST_F(TestExpressionProxy, two_dimensional_value) {
 }
 
 /*****************************************************************************/
-TEST_F(TestExpressionProxy, two_dimensional_expressions_arg_void) {
+TEST_F(TestExpressionProxy, two_dimensional_flat_indexed_expressions_arg_void) {
     cppmh::model::Model<int, double> model;
     auto& expression_proxy = model.create_expressions("e", {2, 3});
 
@@ -1351,7 +1359,7 @@ TEST_F(TestExpressionProxy, two_dimensional_expressions_arg_void) {
 }
 
 /*****************************************************************************/
-TEST_F(TestExpressionProxy, two_dimensional_expressions_arg_int) {
+TEST_F(TestExpressionProxy, two_dimensional_flat_indexed_expressions_arg_int) {
     cppmh::model::Model<int, double> model;
     auto& expression_proxy = model.create_expressions("e", {2, 3});
 

--- a/test/model/test_fixed_size_hash_map.cpp
+++ b/test/model/test_fixed_size_hash_map.cpp
@@ -1,0 +1,131 @@
+/*****************************************************************************/
+// Copyright (c) 2020 Yuji KOGUMA
+// Released under the MIT license
+// https://opensource.org/licenses/mit-license.php
+/*****************************************************************************/
+#include <gtest/gtest.h>
+#include <random>
+#include <cppmh.h>
+
+/*****************************************************************************/
+namespace {
+class TestFixedSizeHashMap : public ::testing::Test {
+   protected:
+    cppmh::utility::IntegerUniformRandom m_random_integer;
+    cppmh::utility::IntegerUniformRandom m_random_positive_integer;
+
+    virtual void SetUp(void) {
+        m_random_integer.setup(-1000, 1000, 0);
+        m_random_positive_integer.setup(1, 1000, 0);
+    }
+    virtual void TearDown() {
+        /// nothing to do
+    }
+    int random_integer(void) {
+        return m_random_integer.generate_random();
+    }
+
+    int random_positive_integer(void) {
+        return m_random_positive_integer.generate_random();
+    }
+};
+
+/*****************************************************************************/
+TEST_F(TestFixedSizeHashMap, initialize) {
+    cppmh::model::FixedSizeHashMap<cppmh::model::Variable<int, double>*, double>
+        fixed_size_hash_map;
+
+    /// static const variable seems not to be allowed in EXPECT_EQ().
+    std::size_t default_bucket_size =
+        cppmh::model::FixedSizeHashMapConstant::DEFAULT_BUCKET_SIZE;
+
+    EXPECT_EQ(static_cast<unsigned int>(0), fixed_size_hash_map.shift_size());
+    EXPECT_EQ(default_bucket_size, fixed_size_hash_map.bucket_size());
+    EXPECT_EQ(default_bucket_size, fixed_size_hash_map.keys().size());
+    EXPECT_EQ(default_bucket_size, fixed_size_hash_map.values().size());
+    EXPECT_EQ(default_bucket_size, fixed_size_hash_map.is_occupied().size());
+
+    EXPECT_EQ(0, fixed_size_hash_map.keys()[0]);
+    EXPECT_EQ(0, fixed_size_hash_map.values()[0]);
+    EXPECT_EQ(0, fixed_size_hash_map.is_occupied()[0]);
+}
+
+/*****************************************************************************/
+TEST_F(TestFixedSizeHashMap, setup) {
+    cppmh::model::FixedSizeHashMap<cppmh::model::Variable<int, double>*, double>
+        fixed_size_hash_map;
+
+    cppmh::model::Model<int, double> model;
+
+    auto& x = model.create_variables("x", {10, 20});
+    auto& y = model.create_variables("y", {20, 30, 40});
+
+    std::unordered_map<cppmh::model::Variable<int, double>*, double>
+        unordered_map;
+
+    for (auto i = 0; i < 10; i++) {
+        for (auto j = 0; j < 20; j++) {
+            unordered_map[&x(i, j)] = random_integer();
+        }
+    }
+
+    for (auto i = 0; i < 20; i++) {
+        for (auto j = 0; j < 30; j++) {
+            for (auto k = 0; k < 40; k++) {
+                unordered_map[&y(i, j, k)] = random_integer();
+            }
+        }
+    }
+    fixed_size_hash_map.setup(unordered_map,
+                              sizeof(cppmh::model::Variable<int, double>));
+
+    EXPECT_EQ((unsigned int)log2(sizeof(cppmh::model::Variable<int, double>)),
+              fixed_size_hash_map.shift_size());
+
+    /// 10 * 20 + 20 * 30 * 40 = 200 + 24000
+    /// 32768 < 24000 * 2(LOAD_MARGIN) < 65536
+    std::size_t expected_bucket_size = 65536;
+    EXPECT_EQ(expected_bucket_size, fixed_size_hash_map.bucket_size());
+    EXPECT_EQ(expected_bucket_size, fixed_size_hash_map.keys().size());
+    EXPECT_EQ(expected_bucket_size, fixed_size_hash_map.values().size());
+    EXPECT_EQ(expected_bucket_size, fixed_size_hash_map.is_occupied().size());
+
+    for (const auto& element : unordered_map) {
+        EXPECT_EQ(element.second, fixed_size_hash_map.at(element.first));
+    }
+}
+
+/*****************************************************************************/
+TEST_F(TestFixedSizeHashMap, at) {
+    /// This method is tested in setup().
+}
+
+/*****************************************************************************/
+TEST_F(TestFixedSizeHashMap, shift_size) {
+    /// This method is tested in initialize() and setup().
+}
+
+/*****************************************************************************/
+TEST_F(TestFixedSizeHashMap, bucket_size) {
+    /// This method is tested in initialize() and setup().
+}
+
+/*****************************************************************************/
+TEST_F(TestFixedSizeHashMap, keys) {
+    /// This method is tested in initialize() and setup().
+}
+
+/*****************************************************************************/
+TEST_F(TestFixedSizeHashMap, values) {
+    /// This method is tested in initialize() and setup().
+}
+
+/*****************************************************************************/
+TEST_F(TestFixedSizeHashMap, is_occupied) {
+    /// This method is tested in initialize() and setup().
+}
+/*****************************************************************************/
+}  // namespace
+/*****************************************************************************/
+// END
+/*****************************************************************************/

--- a/test/model/test_model.cpp
+++ b/test/model/test_model.cpp
@@ -550,6 +550,11 @@ TEST_F(TestModel, setup_has_fixed_variables) {
 }
 
 /*****************************************************************************/
+TEST_F(TestModel, setup_fixed_sensitivities) {
+    /// This method is tested in test_expression.h
+}
+
+/*****************************************************************************/
 TEST_F(TestModel, reset_variable_sense) {
     cppmh::model::Model<int, double> model;
 
@@ -1115,6 +1120,10 @@ TEST_F(TestModel, update_arg_move) {
     auto& expression_proxy =
         model.create_expression("e", variable_proxy.dot(sequence) + 1);
     model.create_constraint("c", variable_proxy.selection());
+
+    for (auto&& expression : expression_proxy.flat_indexed_expressions()) {
+        expression.setup_fixed_sensitivities();
+    }
 
     variable_proxy[0] = 1;
 

--- a/test/model/test_objective.cpp
+++ b/test/model/test_objective.cpp
@@ -131,6 +131,7 @@ TEST_F(TestObjective, evaluate_function_arg_void) {
     auto constant    = random_integer();
 
     expression = sensitivity * variable + constant;
+    expression.setup_fixed_sensitivities();
 
     auto f = [&expression](const cppmh::model::Move<int, double> &a_MOVE) {
         return expression.evaluate(a_MOVE);
@@ -178,6 +179,7 @@ TEST_F(TestObjective, evaluate_function_arg_move) {
     auto constant    = random_integer();
 
     expression = sensitivity * variable + constant;
+    expression.setup_fixed_sensitivities();
 
     auto f = [&expression,
               &variable](const cppmh::model::Move<int, double> &a_MOVE) {


### PR DESCRIPTION
In gcc, std::unordered_map is slow in hashing because it uses modulo operations to fold a large number into range [0, N).  The following code is excerpt from `hashtable_policy.h` (L.422-L.434, gcc 9.3.0).

```c++

  /// Default range hashing function: use division to fold a large number
  /// into the range [0, N).
  struct _Mod_range_hashing
  {
    typedef std::size_t first_argument_type;
    typedef std::size_t second_argument_type;
    typedef std::size_t result_type;

    result_type
    operator()(first_argument_type __num,
	       second_argument_type __den) const noexcept
    { return __num % __den; }
  };
```
The source code `hashtable_policy.h`  also provides the following "mask" version  (L.493-L.504, gcc 9.3.0); however, it does not seem to be used in std::unordered map.

``` c++
  /// Range hashing function assuming that second arg is a power of 2.
  struct _Mask_range_hashing
  {
    typedef std::size_t first_argument_type;
    typedef std::size_t second_argument_type;
    typedef std::size_t result_type;

    result_type
    operator()(first_argument_type __num,
	       second_argument_type __den) const noexcept
    { return __num & (__den - 1); }
  };
```
For efficient evaluations of solutions, a hash map class without modulo operations is prepared. The hash map object will be generated from the corresponding std::unordered map object.

