### PR TITLE
Fix a bug on fast evaluation

### DIFF
--- a/cppmh/solver/local_search/local_search.h
+++ b/cppmh/solver/local_search/local_search.h
@@ -131,15 +131,15 @@ LocalSearchResult<T_Variable, T_Expression> solve(
 
         for (const auto& move_ptr : move_ptrs) {
             model::SolutionScore trial_solution_score;
-            if (model->has_nonlinear_constraint()) {
-                trial_solution_score = model->evaluate(
-                    *move_ptr, local_penalty_coefficient_proxies,
-                    global_penalty_coefficient_proxies);
-            } else {
+            if (model->is_enabled_fast_evaluation()) {
                 trial_solution_score =
                     model->evaluate(*move_ptr, solution_score,
                                     local_penalty_coefficient_proxies,
                                     global_penalty_coefficient_proxies);
+            } else {
+                trial_solution_score = model->evaluate(
+                    *move_ptr, local_penalty_coefficient_proxies,
+                    global_penalty_coefficient_proxies);
             }
 
             number_of_checked_moved++;

--- a/cppmh/solver/solver.h
+++ b/cppmh/solver/solver.h
@@ -94,39 +94,9 @@ model::NamedSolution<T_Variable, T_Expression> solve(
         master_option.print();
     }
 
-    model->verify_problem(master_option.verbose >= Verbose::Warning);
-
-    model->setup_variable_related_constraints();
-    model->setup_variable_sense();
-    model->setup_unique_name();
-
-    model->setup_default_neighborhood(
-        master_option.is_enabled_parallel_neighborhood_update,
-        master_option.verbose >= Verbose::Warning);
-
-    model->setup_fixed_sensitivities(master_option.verbose >= Verbose::Warning);
-
-    /**
-     * If the user-defined_neighborhood is set, default neighborhood should
-     * be disabled to avoid possible inconsistencies.
-     */
-    if (model->neighborhood().is_enabled_user_defined_move()) {
-        model->neighborhood().disable_default_move();
-    }
-
-    model->setup_has_fixed_variables(master_option.verbose >= Verbose::Warning);
-
-    model->verify_and_correct_selection_variables_initial_values(
-        master_option.is_enabled_initial_value_correction,
-        master_option.verbose >= Verbose::Warning);
-
-    model->verify_and_correct_binary_variables_initial_values(
-        master_option.is_enabled_initial_value_correction,
-        master_option.verbose >= Verbose::Warning);
-
-    model->verify_and_correct_integer_variables_initial_values(
-        master_option.is_enabled_initial_value_correction,
-        master_option.verbose >= Verbose::Warning);
+    model->setup(master_option.is_enabled_parallel_neighborhood_update,
+                 master_option.is_enabled_initial_value_correction,
+                 master_option.verbose >= Verbose::Warning);
 
     /**
      * Create local and global penalty coefficient for each constraint.

--- a/cppmh/solver/tabu_search/tabu_search.h
+++ b/cppmh/solver/tabu_search/tabu_search.h
@@ -190,15 +190,16 @@ TabuSearchResult<T_Variable, T_Expression> solve(
     schedule(static)
 #endif
         for (auto i_move = 0; i_move < number_of_moves; i_move++) {
-            if (model->has_nonlinear_constraint()) {
-                trial_solution_scores[i_move] = model->evaluate(
-                    *trial_move_ptrs[i_move], local_penalty_coefficient_proxies,
-                    global_penalty_coefficient_proxies);
-            } else {
+            if (model->is_enabled_fast_evaluation()) {
                 trial_solution_scores[i_move] =
                     model->evaluate(*trial_move_ptrs[i_move], solution_score,
                                     local_penalty_coefficient_proxies,
                                     global_penalty_coefficient_proxies);
+
+            } else {
+                trial_solution_scores[i_move] = model->evaluate(
+                    *trial_move_ptrs[i_move], local_penalty_coefficient_proxies,
+                    global_penalty_coefficient_proxies);
             }
 
             trial_move_scores[i_move] =

--- a/test/model/test_model.cpp
+++ b/test/model/test_model.cpp
@@ -57,6 +57,7 @@ TEST_F(TestModel, initialize) {
     EXPECT_EQ(false, model.is_defined_objective());
     EXPECT_EQ(false, model.has_nonlinear_constraint());
     EXPECT_EQ(false, model.has_nonlinear_objective());
+    EXPECT_EQ(true, model.is_enabled_fast_evaluation());
     EXPECT_EQ(true, model.is_minimization());
     EXPECT_EQ(1.0, model.sign());
 }
@@ -596,6 +597,11 @@ TEST_F(TestModel, setup_variable_related_constraints) {
 
 /*****************************************************************************/
 TEST_F(TestModel, setup_has_nonlinear_constraint) {
+    /// This method is tested in test_neighborhood.h
+}
+
+/*****************************************************************************/
+TEST_F(TestModel, setup_is_enabled_fast_evaluation) {
     /// This method is tested in test_neighborhood.h
 }
 

--- a/test/model/test_model.cpp
+++ b/test/model/test_model.cpp
@@ -55,8 +55,6 @@ TEST_F(TestModel, initialize) {
     EXPECT_EQ(true, model.constraint_names().empty());
 
     EXPECT_EQ(false, model.is_defined_objective());
-    EXPECT_EQ(false, model.has_nonlinear_constraint());
-    EXPECT_EQ(false, model.has_nonlinear_objective());
     EXPECT_EQ(true, model.is_enabled_fast_evaluation());
     EXPECT_EQ(true, model.is_minimization());
     EXPECT_EQ(1.0, model.sign());
@@ -361,8 +359,6 @@ TEST_F(TestModel, minimize_arg_function) {
     EXPECT_EQ(0, model.objective().expression().constant_value());
     EXPECT_EQ(false, model.objective().is_linear());
 
-    EXPECT_EQ(true, model.has_nonlinear_objective());
-
     for (auto&& element : x.flat_indexed_variables()) {
         element = 1;
     }
@@ -445,8 +441,6 @@ TEST_F(TestModel, maximize_arg_function) {
     EXPECT_EQ(0, model.objective().expression().constant_value());
     EXPECT_EQ(false, model.objective().is_linear());
 
-    EXPECT_EQ(true, model.has_nonlinear_objective());
-
     for (auto&& element : x.flat_indexed_variables()) {
         element = 1;
     }
@@ -514,13 +508,8 @@ TEST_F(TestModel, is_defined_objective) {
 }
 
 /*****************************************************************************/
-TEST_F(TestModel, has_nonlinear_constraint) {
-    /// This method is tested in setup_has_nonlinear_constraint().
-}
-
-/*****************************************************************************/
-TEST_F(TestModel, has_nonlinear_objective) {
-    /// This method is tested in minimize_arg_function() and so on.
+TEST_F(TestModel, is_enabled_fast_evaluation) {
+    /// This method is tested in setup_is_enabled_fast_evaluation().
 }
 
 /*****************************************************************************/
@@ -559,6 +548,46 @@ TEST_F(TestModel, neighborhood) {
 }
 
 /*****************************************************************************/
+TEST_F(TestModel, setup) {
+    /// This method is tested in the following submethods.
+}
+
+/*****************************************************************************/
+TEST_F(TestModel, verify_problem) {
+    /// No decision variables.
+    {
+        cppmh::model::Model<int, double> model;
+        ASSERT_THROW(model.verify_problem(false), std::logic_error);
+    }
+
+    /// No constraint functions.
+    {
+        cppmh::model::Model<int, double> model;
+
+        auto& x = model.create_variable("x");
+        model.minimize(x);
+        model.verify_problem(false);
+    }
+
+    /// No objective function.
+    {
+        cppmh::model::Model<int, double> model;
+
+        auto& x = model.create_variable("x");
+        model.create_constraint("g", x == 1);
+        model.verify_problem(false);
+    }
+
+    /// No constraint functions and no objective function
+    {
+        cppmh::model::Model<int, double> model;
+
+        [[maybe_unused]] auto& x = model.create_variable("x");
+        ASSERT_THROW(model.verify_problem(false), std::logic_error);
+    }
+}
+
+/*****************************************************************************/
 TEST_F(TestModel, setup_variable_related_constraints) {
     cppmh::model::Model<int, double> model;
 
@@ -593,16 +622,6 @@ TEST_F(TestModel, setup_variable_related_constraints) {
                                   y(i, j).related_constraint_ptrs().end());
         }
     }
-}
-
-/*****************************************************************************/
-TEST_F(TestModel, setup_has_nonlinear_constraint) {
-    /// This method is tested in test_neighborhood.h
-}
-
-/*****************************************************************************/
-TEST_F(TestModel, setup_is_enabled_fast_evaluation) {
-    /// This method is tested in test_neighborhood.h
 }
 
 /*****************************************************************************/
@@ -650,53 +669,89 @@ TEST_F(TestModel, setup_unique_name) {
 }
 
 /*****************************************************************************/
-TEST_F(TestModel, setup_has_fixed_variables) {
-    /// This method is tested in test_neighborhood.h
-}
-
-/*****************************************************************************/
-TEST_F(TestModel, verify_problem) {
-    /// No decision variables.
-    {
-        cppmh::model::Model<int, double> model;
-        ASSERT_THROW(model.verify_problem(false), std::logic_error);
-    }
-
-    /// No constraint functions.
+TEST_F(TestModel, setup_is_enabled_fast_evaluation) {
+    /// Constraint: linear
+    /// Objective: linear
+    /// User-defined neighborhood: None
     {
         cppmh::model::Model<int, double> model;
 
         auto& x = model.create_variable("x");
+
+        model.create_constraint("g", x <= 0);
         model.minimize(x);
-        model.verify_problem(false);
+
+        model.setup_is_enabled_fast_evaluation();
+
+        EXPECT_EQ(true, model.is_enabled_fast_evaluation());
     }
 
-    /// No objective function.
+    /// Constraint: nonlinear (user-defined lambda)
+    /// Objective: linear
+    /// User-defined neighborhood: None
     {
         cppmh::model::Model<int, double> model;
 
         auto& x = model.create_variable("x");
-        model.create_constraint("g", x == 1);
-        model.verify_problem(false);
+
+        std::function<double(const cppmh::model::Move<int, double>&)> g =
+            [&x](const cppmh::model::Move<int, double>& a_MOVE) {
+                return x.evaluate(a_MOVE);
+            };
+
+        model.create_constraint("g", g <= 0);
+        model.minimize(x);
+
+        model.setup_is_enabled_fast_evaluation();
+
+        EXPECT_EQ(false, model.is_enabled_fast_evaluation());
     }
 
-    /// No constraint functions and no objective function
+    /// Constraint: linear
+    /// Objective: nonlinear (user-defined lambda)
+    /// User-defined neighborhood: None
     {
         cppmh::model::Model<int, double> model;
 
-        [[maybe_unused]] auto& x = model.create_variable("x");
-        ASSERT_THROW(model.verify_problem(false), std::logic_error);
+        auto& x = model.create_variable("x");
+
+        std::function<double(const cppmh::model::Move<int, double>&)> f =
+            [&x](const cppmh::model::Move<int, double>& a_MOVE) {
+                return x.evaluate(a_MOVE);
+            };
+
+        model.create_constraint("g", x <= 0);
+        model.minimize(f);
+
+        model.setup_is_enabled_fast_evaluation();
+
+        EXPECT_EQ(false, model.is_enabled_fast_evaluation());
+    }
+
+    /// Constraint: linear
+    /// Objective: linear
+    /// User-defined neighborhood: Yes
+    {
+        cppmh::model::Model<int, double> model;
+
+        auto& x = model.create_variable("x");
+
+        model.create_constraint("g", x <= 0);
+        model.minimize(x);
+
+        auto move_updater =
+            [&x](std::vector<cppmh::model::Move<int, double>>* a_moves) { ; };
+
+        model.neighborhood().set_user_defined_move_updater(move_updater);
+        model.setup_is_enabled_fast_evaluation();
+
+        EXPECT_EQ(false, model.is_enabled_fast_evaluation());
     }
 }
 
 /*****************************************************************************/
 TEST_F(TestModel, setup_default_neighborhood) {
     /// This method is tested in test_neighborhood.h
-}
-
-/*****************************************************************************/
-TEST_F(TestModel, setup_fixed_sensitivities) {
-    /// This method is tested in test_expression.h
 }
 
 /*****************************************************************************/
@@ -711,7 +766,6 @@ TEST_F(TestModel, verify_and_correct_selection_variables_initial_values) {
         x(0).fix_by(2);
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
 
         ASSERT_THROW(
             model.verify_and_correct_selection_variables_initial_values(true,
@@ -728,7 +782,6 @@ TEST_F(TestModel, verify_and_correct_selection_variables_initial_values) {
         x(0).fix_by(2);
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
 
         ASSERT_THROW(
             model.verify_and_correct_selection_variables_initial_values(false,
@@ -745,7 +798,6 @@ TEST_F(TestModel, verify_and_correct_selection_variables_initial_values) {
         x(0).fix_by(1);
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
 
         model.verify_and_correct_selection_variables_initial_values(true,
                                                                     false);
@@ -761,7 +813,6 @@ TEST_F(TestModel, verify_and_correct_selection_variables_initial_values) {
         x(0).fix_by(1);
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
 
         model.verify_and_correct_selection_variables_initial_values(false,
                                                                     false);
@@ -778,7 +829,6 @@ TEST_F(TestModel, verify_and_correct_selection_variables_initial_values) {
         x(1).fix_by(1);
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
 
         ASSERT_THROW(
             model.verify_and_correct_selection_variables_initial_values(true,
@@ -796,7 +846,6 @@ TEST_F(TestModel, verify_and_correct_selection_variables_initial_values) {
         x(1).fix_by(1);
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
 
         ASSERT_THROW(
             model.verify_and_correct_selection_variables_initial_values(false,
@@ -814,7 +863,6 @@ TEST_F(TestModel, verify_and_correct_selection_variables_initial_values) {
         x(1) = 3;
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
 
         model.verify_and_correct_selection_variables_initial_values(true,
                                                                     false);
@@ -833,7 +881,6 @@ TEST_F(TestModel, verify_and_correct_selection_variables_initial_values) {
         x(1) = 3;
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
 
         ASSERT_THROW(
             model.verify_and_correct_selection_variables_initial_values(false,
@@ -849,7 +896,6 @@ TEST_F(TestModel, verify_and_correct_selection_variables_initial_values) {
         model.create_constraint("g", x.selection());
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
 
         model.verify_and_correct_selection_variables_initial_values(true,
                                                                     false);
@@ -868,7 +914,6 @@ TEST_F(TestModel, verify_and_correct_selection_variables_initial_values) {
         model.create_constraint("g", x.selection());
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
 
         ASSERT_THROW(
             model.verify_and_correct_selection_variables_initial_values(false,
@@ -885,7 +930,6 @@ TEST_F(TestModel, verify_and_correct_selection_variables_initial_values) {
         x(0) = 1;
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
 
         model.verify_and_correct_selection_variables_initial_values(true,
                                                                     false);
@@ -902,7 +946,6 @@ TEST_F(TestModel, verify_and_correct_selection_variables_initial_values) {
         x(0) = 1;
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
 
         model.verify_and_correct_selection_variables_initial_values(false,
                                                                     false);
@@ -920,7 +963,6 @@ TEST_F(TestModel, verify_and_correct_selection_variables_initial_values) {
         x(1) = 1;
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
 
         model.verify_and_correct_selection_variables_initial_values(true,
                                                                     false);
@@ -939,7 +981,6 @@ TEST_F(TestModel, verify_and_correct_selection_variables_initial_values) {
         x(1) = 1;
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
 
         ASSERT_THROW(
             model.verify_and_correct_selection_variables_initial_values(false,
@@ -957,7 +998,6 @@ TEST_F(TestModel, verify_and_correct_selection_variables_initial_values) {
         x(1).fix_by(1);
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
 
         model.verify_and_correct_selection_variables_initial_values(true,
                                                                     false);
@@ -975,7 +1015,6 @@ TEST_F(TestModel, verify_and_correct_selection_variables_initial_values) {
         x(1).fix_by(1);
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
 
         ASSERT_THROW(
             model.verify_and_correct_selection_variables_initial_values(false,
@@ -994,7 +1033,6 @@ TEST_F(TestModel, verify_and_correct_binary_variables_initial_values) {
         x(0).fix_by(2);
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
 
         ASSERT_THROW(model.verify_and_correct_binary_variables_initial_values(
                          true, false),
@@ -1009,7 +1047,6 @@ TEST_F(TestModel, verify_and_correct_binary_variables_initial_values) {
         x(0).fix_by(-1);
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
 
         ASSERT_THROW(model.verify_and_correct_binary_variables_initial_values(
                          false, false),
@@ -1025,7 +1062,6 @@ TEST_F(TestModel, verify_and_correct_binary_variables_initial_values) {
         x(1)    = -1;
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
 
         model.verify_and_correct_binary_variables_initial_values(true, false);
         EXPECT_EQ(1, x(0).value());
@@ -1041,7 +1077,6 @@ TEST_F(TestModel, verify_and_correct_binary_variables_initial_values) {
         x(1)    = -1;
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
 
         ASSERT_THROW(model.verify_and_correct_binary_variables_initial_values(
                          false, false),
@@ -1059,7 +1094,6 @@ TEST_F(TestModel, verify_and_correct_integer_variables_initial_values) {
         x(0).fix_by(11);
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
 
         ASSERT_THROW(model.verify_and_correct_integer_variables_initial_values(
                          true, false),
@@ -1074,7 +1108,6 @@ TEST_F(TestModel, verify_and_correct_integer_variables_initial_values) {
         x(0).fix_by(-11);
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
 
         ASSERT_THROW(model.verify_and_correct_integer_variables_initial_values(
                          false, false),
@@ -1090,7 +1123,6 @@ TEST_F(TestModel, verify_and_correct_integer_variables_initial_values) {
         x(1)    = -11;
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
 
         model.verify_and_correct_integer_variables_initial_values(true, false);
         EXPECT_EQ(10, x(0).value());
@@ -1106,12 +1138,16 @@ TEST_F(TestModel, verify_and_correct_integer_variables_initial_values) {
         x(1)    = -11;
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
 
         ASSERT_THROW(model.verify_and_correct_integer_variables_initial_values(
                          false, false),
                      std::logic_error);
     }
+}
+
+/*****************************************************************************/
+TEST_F(TestModel, setup_fixed_sensitivities) {
+    /// This method is tested in test_expression.h
 }
 
 /*****************************************************************************/

--- a/test/model/test_neighborhood.cpp
+++ b/test/model/test_neighborhood.cpp
@@ -61,7 +61,6 @@ TEST_F(TestNeighborhood, setup_has_fixed_variables) {
         [[maybe_unused]] auto& y = model.create_variable("y", 0, 1);
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
         EXPECT_EQ(false, model.neighborhood().has_fixed_variables());
     }
 
@@ -73,7 +72,6 @@ TEST_F(TestNeighborhood, setup_has_fixed_variables) {
         x.fix_by(1);
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
         EXPECT_EQ(true, model.neighborhood().has_fixed_variables());
     }
 
@@ -85,7 +83,6 @@ TEST_F(TestNeighborhood, setup_has_fixed_variables) {
         y.fix_by(1);
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
         EXPECT_EQ(true, model.neighborhood().has_fixed_variables());
     }
 
@@ -100,7 +97,6 @@ TEST_F(TestNeighborhood, setup_has_fixed_variables) {
         y.unfix();
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
         EXPECT_EQ(false, model.neighborhood().has_fixed_variables());
     }
 
@@ -112,7 +108,6 @@ TEST_F(TestNeighborhood, setup_has_fixed_variables) {
         [[maybe_unused]] auto& y = model.create_variables("y", 10, 0, 1);
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
         EXPECT_EQ(false, model.neighborhood().has_fixed_variables());
     }
 
@@ -124,7 +119,6 @@ TEST_F(TestNeighborhood, setup_has_fixed_variables) {
         x(0).fix_by(1);
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
         EXPECT_EQ(true, model.neighborhood().has_fixed_variables());
     }
 
@@ -136,7 +130,6 @@ TEST_F(TestNeighborhood, setup_has_fixed_variables) {
         y(0).fix_by(1);
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
         EXPECT_EQ(true, model.neighborhood().has_fixed_variables());
     }
 
@@ -151,7 +144,6 @@ TEST_F(TestNeighborhood, setup_has_fixed_variables) {
         y(0).unfix();
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
         EXPECT_EQ(false, model.neighborhood().has_fixed_variables());
     }
 
@@ -163,7 +155,6 @@ TEST_F(TestNeighborhood, setup_has_fixed_variables) {
         [[maybe_unused]] auto& y = model.create_variables("y", {10, 10}, 0, 1);
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
         EXPECT_EQ(false, model.neighborhood().has_fixed_variables());
     }
 
@@ -175,7 +166,6 @@ TEST_F(TestNeighborhood, setup_has_fixed_variables) {
         x(0, 0).fix_by(1);
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
         EXPECT_EQ(true, model.neighborhood().has_fixed_variables());
     }
 
@@ -187,7 +177,6 @@ TEST_F(TestNeighborhood, setup_has_fixed_variables) {
         y(0, 0).fix_by(1);
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
         EXPECT_EQ(true, model.neighborhood().has_fixed_variables());
     }
 
@@ -202,8 +191,6 @@ TEST_F(TestNeighborhood, setup_has_fixed_variables) {
         y(0, 0).unfix();
 
         model.setup_default_neighborhood(false, false);
-        model.setup_has_fixed_variables(false);
-
         EXPECT_EQ(false, model.neighborhood().has_fixed_variables());
     }
 }
@@ -252,7 +239,6 @@ TEST_F(TestNeighborhood, categorize_variables_and_constraints) {
     model.create_constraint("c6", x4.selection());
 
     model.setup_default_neighborhood(false, false);
-    model.setup_has_fixed_variables(false);
 
     EXPECT_EQ(5, static_cast<int>(model.neighborhood().selections().size()));
 
@@ -537,8 +523,6 @@ TEST_F(TestNeighborhood, setup_move_updater) {
     y(0, 2) = 10;
 
     model.setup_default_neighborhood(false, false);
-    model.setup_has_fixed_variables(false);
-
     EXPECT_EQ(false, model.neighborhood().is_enabled_user_defined_move());
 
     /// Set initial values for selection variables.
@@ -694,8 +678,7 @@ TEST_F(TestNeighborhood, set_user_defined_move_updater) {
     model.neighborhood().disable_binary_move();
     model.neighborhood().disable_integer_move();
 
-    model.setup_has_fixed_variables(false);
-
+    model.setup_default_neighborhood(false, false);
     model.neighborhood().update_moves();
 
     EXPECT_EQ(false, model.neighborhood().is_enabled_selection_move());
@@ -728,7 +711,6 @@ TEST_F(TestNeighborhood, shuffle_moves) {
     [[maybe_unused]] auto& c = model.create_constraint("c", x.selection());
 
     model.setup_default_neighborhood(false, false);
-    model.setup_has_fixed_variables(false);
     model.neighborhood().update_moves();
 
     auto         before_move_ptrs = model.neighborhood().move_ptrs();


### PR DESCRIPTION
This PR fixes a bug that the fast evaluation does not work if the user-defined neighborhood is enabled. Now cppmh disables the fast evaluation for such cases.