### PR TITLE
Fix bugs on presolve

### DIFF
--- a/application/cppmh/utility/option_utility.h
+++ b/application/cppmh/utility/option_utility.h
@@ -83,6 +83,12 @@ inline cppmh::solver::Option read_option(const std::string &a_FILE_NAME) {
               option_object);
 
     /**************************************************************************/
+    /// is_enabled_presolve
+    read_json(&option.is_enabled_presolve,  //
+              "is_enabled_presolve",        //
+              option_object);
+
+    /**************************************************************************/
     /// is_enabled_initial_value_correction
     read_json(&option.is_enabled_initial_value_correction,  //
               "is_enabled_initial_value_correction",        //

--- a/test/model/test_model.cpp
+++ b/test/model/test_model.cpp
@@ -1437,6 +1437,43 @@ TEST_F(TestModel, remove_implicit_singleton_constraints) {
         EXPECT_EQ(10, x.upper_bound());
         EXPECT_EQ(false, g.is_enabled());
     }
+
+    {
+        cppmh::model::Model<int, double> model;
+
+        auto& x = model.create_variable("x", -10, 10);
+        auto& g = model.create_constraint("g", -3 * x + 1 == 7);
+
+        model.remove_implicit_singleton_constraints(false);
+        EXPECT_EQ(true, x.is_fixed());
+        EXPECT_EQ(-2, x.value());
+        EXPECT_EQ(false, g.is_enabled());
+    }
+    {
+        cppmh::model::Model<int, double> model;
+
+        auto& x = model.create_variable("x", -10, 10);
+        auto& g = model.create_constraint("g", -3 * x + 1 <= 7);
+
+        model.remove_implicit_singleton_constraints(false);
+        EXPECT_EQ(false, x.is_fixed());
+        EXPECT_EQ(-2, x.lower_bound());
+        EXPECT_EQ(10, x.upper_bound());
+        EXPECT_EQ(false, g.is_enabled());
+    }
+    {
+        cppmh::model::Model<int, double> model;
+
+        auto& x = model.create_variable("x", -10, 10);
+        auto& g = model.create_constraint("g", -3 * x + 1 >= 7);
+
+        model.remove_implicit_singleton_constraints(false);
+        EXPECT_EQ(false, x.is_fixed());
+        EXPECT_EQ(-10, x.lower_bound());
+        EXPECT_EQ(-2, x.upper_bound());
+        EXPECT_EQ(false, g.is_enabled());
+    }
+
     {
         cppmh::model::Model<int, double> model;
 
@@ -1481,6 +1518,48 @@ TEST_F(TestModel, remove_implicit_singleton_constraints) {
     {
         cppmh::model::Model<int, double> model;
 
+        auto& x = model.create_variable("x", -10, 10);
+        auto& y = model.create_variable("y", 0, 1);
+        auto& g = model.create_constraint("g", -3 * x + y == 7);
+        y.fix_by(1);
+
+        model.remove_implicit_singleton_constraints(false);
+        EXPECT_EQ(true, x.is_fixed());
+        EXPECT_EQ(-2, x.value());
+        EXPECT_EQ(false, g.is_enabled());
+    }
+    {
+        cppmh::model::Model<int, double> model;
+
+        auto& x = model.create_variable("x", -10, 10);
+        auto& y = model.create_variable("y", 0, 1);
+        auto& g = model.create_constraint("g", -3 * x + y <= 7);
+        y.fix_by(1);
+
+        model.remove_implicit_singleton_constraints(false);
+        EXPECT_EQ(false, x.is_fixed());
+        EXPECT_EQ(-2, x.lower_bound());
+        EXPECT_EQ(10, x.upper_bound());
+        EXPECT_EQ(false, g.is_enabled());
+    }
+    {
+        cppmh::model::Model<int, double> model;
+
+        auto& x = model.create_variable("x", -10, 10);
+        auto& y = model.create_variable("y", 0, 1);
+        auto& g = model.create_constraint("g", -3 * x + y >= 7);
+        y.fix_by(1);
+
+        model.remove_implicit_singleton_constraints(false);
+        EXPECT_EQ(false, x.is_fixed());
+        EXPECT_EQ(-10, x.lower_bound());
+        EXPECT_EQ(-2, x.upper_bound());
+        EXPECT_EQ(false, g.is_enabled());
+    }
+
+    {
+        cppmh::model::Model<int, double> model;
+
         auto& x = model.create_variable("x", 0, 10);
         auto& g = model.create_constraint("g", 3 * x + 1 == 7);
         x.fix_by(2);
@@ -1506,6 +1585,40 @@ TEST_F(TestModel, remove_implicit_singleton_constraints) {
         auto& x = model.create_variable("x", 0, 10);
         auto& g = model.create_constraint("g", 3 * x + 1 >= 7);
         x.fix_by(3);
+
+        model.remove_implicit_singleton_constraints(false);
+        EXPECT_EQ(true, x.is_fixed());
+        EXPECT_EQ(false, g.is_enabled());
+    }
+
+    {
+        cppmh::model::Model<int, double> model;
+
+        auto& x = model.create_variable("x", -10, 10);
+        auto& g = model.create_constraint("g", -3 * x + 1 == 7);
+        x.fix_by(-2);
+
+        model.remove_implicit_singleton_constraints(false);
+        EXPECT_EQ(true, x.is_fixed());
+        EXPECT_EQ(false, g.is_enabled());
+    }
+    {
+        cppmh::model::Model<int, double> model;
+
+        auto& x = model.create_variable("x", -10, 10);
+        auto& g = model.create_constraint("g", -3 * x + 1 <= 7);
+        x.fix_by(-2);
+
+        model.remove_implicit_singleton_constraints(false);
+        EXPECT_EQ(true, x.is_fixed());
+        EXPECT_EQ(false, g.is_enabled());
+    }
+    {
+        cppmh::model::Model<int, double> model;
+
+        auto& x = model.create_variable("x", -10, 10);
+        auto& g = model.create_constraint("g", -3 * x + 1 >= 7);
+        x.fix_by(-2);
 
         model.remove_implicit_singleton_constraints(false);
         EXPECT_EQ(true, x.is_fixed());


### PR DESCRIPTION
This PR fixes a bug that cppmh fails in presolving a singleton constraint with a negative coefficient (issue #44).
This PR includes the following commits:
